### PR TITLE
IN-421 - Add isRemote to location and fix work order group type

### DIFF
--- a/src/FieldNation/ServiceLocation.php
+++ b/src/FieldNation/ServiceLocation.php
@@ -19,6 +19,7 @@ class ServiceLocation implements ServiceLocationInterface
     private $contactName;
     private $contactPhone;
     private $contactEmail;
+    private $isRemote;
 
     /**
      * Set the location type.
@@ -261,5 +262,24 @@ class ServiceLocation implements ServiceLocationInterface
     public function getContactEmail()
     {
         return $this->contactEmail;
+    }
+
+    /**
+     * Set the is remote flag
+     *
+     * @param boolean $flag
+     * @return self
+     */
+    public function setIsRemote($flag) {
+        $this->isRemote = (boolean) $flag;
+    }
+
+    /**
+     * Get the is remote flag
+     *
+     * @return boolean
+     */
+    public function getIsRemote() {
+        return $this->isRemote;
     }
 }

--- a/src/FieldNation/ServiceLocationInterface.php
+++ b/src/FieldNation/ServiceLocationInterface.php
@@ -173,4 +173,19 @@ interface ServiceLocationInterface
      * @return string
      */
     public function getContactEmail();
+
+    /**
+     * Set the is remote flag
+     *
+     * @param boolean $flag
+     * @return self
+     */
+    public function setIsRemote($flag);
+
+    /**
+     * Get the is remote flag
+     *
+     * @return boolean
+     */
+    public function getIsRemote();
 }

--- a/src/FieldNation/TypeValidator.php
+++ b/src/FieldNation/TypeValidator.php
@@ -73,7 +73,7 @@ class TypeValidator
         self::validate('bool', $wo->getIsPrintable(), 'validatePrimitive', true, 'isPrintable');
 
         // Optional Fields
-        self::validate(GroupInterface::class, $wo->getGroup(), 'validateType', false, 'group');
+        self::validate('string', $wo->getGroup(), 'validatePrimitive', false, 'group');
         self::validate(AdditionalFieldInterface::class, $wo->getAdditionalFields(), 'validateCollection', false);
         self::validate(LabelInterface::class, $wo->getLabels(), 'validateCollection', false);
         self::validate(

--- a/tests/FieldNation/TypeValidatorTest.php
+++ b/tests/FieldNation/TypeValidatorTest.php
@@ -36,7 +36,6 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
     public function testWorkOrderSerializerInterfaceIsValidated()
     {
         $wo = $this->createMock(WorkOrderSerializerInterface::class);
-        $group = $this->createMock(GroupInterface::class);
         $description = $this->createMock(ServiceDescriptionInterface::class);
         $location = $this->createMock(ServiceLocationInterface::class);
         $time = $this->createMock(TimeRangeInterface::class);
@@ -57,7 +56,6 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
             $this->createMock(CloseoutRequirementInterface::class)
         );
 
-        $wo->method('getGroup')->willReturn($group);
         $wo->method('getDescription')->willReturn($description);
         $wo->method('getLocation')->willReturn($location);
         $wo->method('getStartTime')->willReturn($time);


### PR DESCRIPTION
* add isRemote flag to location to allow creating remote work orders
* fixes the workorder group type which should be string. Group class is actually Provider Group used for routing to a group